### PR TITLE
Fix entropy averaging and add regression test

### DIFF
--- a/rank_preserving_calibration/utils.py
+++ b/rank_preserving_calibration/utils.py
@@ -315,8 +315,8 @@ def analyze_calibration_result(P: np.ndarray, result, M: np.ndarray) -> dict:
     calibrated_confidence = np.mean(np.max(Q, axis=1))
     
     # Distribution changes
-    original_entropy = np.mean([-np.sum(P * np.log(P + 1e-10), axis=1)])
-    calibrated_entropy = np.mean([-np.sum(Q * np.log(Q + 1e-10), axis=1)])
+    original_entropy = np.mean(-np.sum(P * np.log(P + 1e-10), axis=1))
+    calibrated_entropy = np.mean(-np.sum(Q * np.log(Q + 1e-10), axis=1))
     
     # Marginal correction magnitude
     marginal_correction = np.abs(P.sum(axis=0) - M).sum()

--- a/tests/test_entropy.py
+++ b/tests/test_entropy.py
@@ -1,0 +1,30 @@
+"""Tests for entropy computation in analyze_calibration_result."""
+
+import numpy as np
+from types import SimpleNamespace
+
+from rank_preserving_calibration import analyze_calibration_result
+
+
+def test_entropy_regression():
+    """Verify entropy calculations on a known small matrix."""
+    P = np.array([[0.6, 0.4], [0.5, 0.5]])
+    Q = np.array([[0.7, 0.3], [0.4, 0.6]])
+    M = Q.sum(axis=0)
+
+    result = SimpleNamespace(
+        Q=Q, converged=True, iterations=0, final_change=0.0, max_rank_violation=0.0
+    )
+
+    analysis = analyze_calibration_result(P, result, M)
+
+    expected_P_entropy = np.mean(-np.sum(P * np.log(P + 1e-10), axis=1))
+    expected_Q_entropy = np.mean(-np.sum(Q * np.log(Q + 1e-10), axis=1))
+
+    assert np.isclose(
+        analysis["distribution_impact"]["original_entropy"], expected_P_entropy
+    )
+    assert np.isclose(
+        analysis["distribution_impact"]["calibrated_entropy"], expected_Q_entropy
+    )
+


### PR DESCRIPTION
## Summary
- simplify entropy averaging in `analyze_calibration_result`
- add regression test verifying entropy calculations on a known matrix

## Testing
- `pytest tests/test_entropy.py` *(fails: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68a22b973904832fb20fb05c48e0d0b9