### PR TITLE
refactor: move data helpers out of package

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,10 +60,6 @@ Calibrate using Dykstra's alternating projections (recommended).
 
 Calibrate using ADMM optimization with penalty parameter `rho`.
 
-### `create_test_case(case_type, N, J, **kwargs)`
-
-Generate synthetic test data for various scenarios.
-
 ## Arguments
 
 | Parameter | Type | Description |

--- a/examples/data_utils.py
+++ b/examples/data_utils.py
@@ -1,8 +1,7 @@
-"""
-Utility functions for rank-preserving calibration.
+"""Data utilities for examples and tests.
 
-This module provides functions for generating synthetic test cases and
-analyzing calibration results.
+This module collects helper functions for generating synthetic datasets and
+analyzing calibration results used throughout the examples and test suite.
 """
 
 from typing import Optional, Tuple

--- a/examples/example.ipynb
+++ b/examples/example.ipynb
@@ -25,22 +25,25 @@
     "import numpy as np\n",
     "import matplotlib.pyplot as plt\n",
     "\n",
-    "# Import our calibration package\n",
+    "# Import calibration package\n",
     "from rank_preserving_calibration import (\n",
-    "    calibrate_dykstra, \n",
+    "    calibrate_dykstra,\n",
     "    calibrate_admm,\n",
+    ")\n",
+    "\n",
+    "from examples.data_utils import (\n",
     "    create_test_case,\n",
     "    create_realistic_classifier_case,\n",
     "    create_survey_reweighting_case,\n",
-    "    analyze_calibration_result\n",
+    "    analyze_calibration_result,\n",
     ")\n",
     "\n",
     "# Set style for nice plots\n",
     "plt.style.use('default')\n",
     "# Use matplotlib's built-in color cycle\n",
-    "plt.rcParams['axes.prop_cycle'] = plt.cycler('color', \n",
+    "plt.rcParams['axes.prop_cycle'] = plt.cycler('color',\n",
     "    ['#1f77b4', '#ff7f0e', '#2ca02c', '#d62728', '#9467bd', '#8c564b'])\n",
-    "np.random.seed(42)"
+    "np.random.seed(42)\n"
    ]
   },
   {
@@ -270,8 +273,8 @@
       "\n",
       "Calibration Impact:\n",
       "Prediction changes: 0.4%\n",
-      "Confidence change: 0.803 → 0.764\n",
-      "Entropy change: 0.627 → 0.776\n"
+      "Confidence change: 0.803 \u2192 0.764\n",
+      "Entropy change: 0.627 \u2192 0.776\n"
      ]
     },
     {
@@ -303,8 +306,8 @@
     "\n",
     "print(f\"\\nCalibration Impact:\")\n",
     "print(f\"Prediction changes: {analysis['prediction_impact']['prediction_changes']:.1%}\")\n",
-    "print(f\"Confidence change: {analysis['prediction_impact']['original_confidence']:.3f} → {analysis['prediction_impact']['calibrated_confidence']:.3f}\")\n",
-    "print(f\"Entropy change: {analysis['distribution_impact']['original_entropy']:.3f} → {analysis['distribution_impact']['calibrated_entropy']:.3f}\")"
+    "print(f\"Confidence change: {analysis['prediction_impact']['original_confidence']:.3f} \u2192 {analysis['prediction_impact']['calibrated_confidence']:.3f}\")\n",
+    "print(f\"Entropy change: {analysis['distribution_impact']['original_entropy']:.3f} \u2192 {analysis['distribution_impact']['calibrated_entropy']:.3f}\")"
    ]
   },
   {
@@ -397,10 +400,10 @@
       "Reweighted results: [0.3555 0.4315 0.161  0.052 ]\n",
       "\n",
       "Poll Result Changes:\n",
-      "Candidate A: 0.361 → 0.355 (-0.006)\n",
-      "Candidate B: 0.394 → 0.431 (+0.038)\n",
-      "Candidate C: 0.170 → 0.161 (-0.009)\n",
-      "Undecided: 0.075 → 0.052 (-0.023)\n"
+      "Candidate A: 0.361 \u2192 0.355 (-0.006)\n",
+      "Candidate B: 0.394 \u2192 0.431 (+0.038)\n",
+      "Candidate C: 0.170 \u2192 0.161 (-0.009)\n",
+      "Undecided: 0.075 \u2192 0.052 (-0.023)\n"
      ]
     }
    ],
@@ -430,7 +433,7 @@
     "print(f\"\\nPoll Result Changes:\")\n",
     "for i, cat in enumerate(categories):\n",
     "    shift = reweighted_results[i] - original_results[i]\n",
-    "    print(f\"{cat}: {original_results[i]:.3f} → {reweighted_results[i]:.3f} ({shift:+.3f})\")"
+    "    print(f\"{cat}: {original_results[i]:.3f} \u2192 {reweighted_results[i]:.3f} ({shift:+.3f})\")"
    ]
   },
   {

--- a/rank_preserving_calibration/__init__.py
+++ b/rank_preserving_calibration/__init__.py
@@ -7,11 +7,15 @@ algorithms including Dykstra's alternating projections and ADMM optimization.
 Example
 -------
 >>> import numpy as np
->>> from rank_preserving_calibration import calibrate_dykstra, create_test_case
->>> 
->>> # Generate test data
->>> P, M = create_test_case("random", N=100, J=4, seed=42)
->>> 
+>>> from rank_preserving_calibration import calibrate_dykstra
+>>>
+>>> P = np.array([
+...     [0.6, 0.3, 0.1],
+...     [0.2, 0.5, 0.3],
+...     [0.1, 0.2, 0.7],
+... ])
+>>> M = np.array([1.0, 1.0, 1.0])
+>>>
 >>> # Calibrate probabilities
 >>> result = calibrate_dykstra(P, M)
 >>> print(f"Converged: {result.converged}")
@@ -32,13 +36,6 @@ from .calibration import (
     CalibrationError
 )
 
-from .utils import (
-    create_test_case,
-    create_realistic_classifier_case,
-    create_survey_reweighting_case,
-    analyze_calibration_result
-)
-
 # Legacy aliases for backward compatibility
 calibrate_rank_preserving = calibrate_dykstra
 admm_rank_preserving_simplex_marginals = calibrate_dykstra
@@ -53,12 +50,6 @@ __all__ = [
     "CalibrationResult",
     "ADMMResult",
     "CalibrationError",
-    
-    # Utility functions
-    "create_test_case",
-    "create_realistic_classifier_case", 
-    "create_survey_reweighting_case",
-    "analyze_calibration_result",
     
     # Legacy aliases
     "calibrate_rank_preserving",

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -7,13 +7,13 @@ Run with: python -m pytest tests/
 import numpy as np
 import pytest
 from rank_preserving_calibration import (
-    calibrate_dykstra, 
+    calibrate_dykstra,
     calibrate_admm,
-    create_test_case,
     CalibrationResult,
     ADMMResult,
     CalibrationError
 )
+from examples.data_utils import create_test_case
 
 
 class TestBasicFunctionality:


### PR DESCRIPTION
## Summary
- move synthetic data utilities to `examples/data_utils.py`
- drop utility exports from package and documentation
- update tests and examples to use new data helper module

## Testing
- `pytest -q` *(fails: No module named 'numpy')*


------
https://chatgpt.com/codex/tasks/task_e_68a22b96abb4832f8b2faec775063a8b