### PR TITLE
Remove SciPy import from survey reweighting helper

### DIFF
--- a/rank_preserving_calibration/utils.py
+++ b/rank_preserving_calibration/utils.py
@@ -227,16 +227,6 @@ def create_survey_reweighting_case(N: int = 1000, seed: Optional[int] = None) ->
     Tuple[np.ndarray, np.ndarray, dict]
         P (survey responses), M (target demographics), info dict.
     """
-    # Optional scipy import
-    try:
-        from scipy.stats import dirichlet
-    except ImportError:
-        class dirichlet:
-            @staticmethod
-            def rvs(alpha, size=1):
-                samples = np.random.gamma(alpha, size=(size, len(alpha)))
-                return samples / samples.sum(axis=1, keepdims=True)
-    
     if seed is not None:
         np.random.seed(seed)
     


### PR DESCRIPTION
## Summary
- drop unused SciPy import block in `create_survey_reweighting_case`

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `pip install numpy` *(fails: Could not find a version that satisfies the requirement numpy)*
- `python - <<'PY' ...` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68a22b980bd0832faab98772f4c9187e