### PR TITLE
Specify PyPI publish option

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,8 +56,7 @@ jobs:
     - name: Publish to PyPI
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
-        # This uses PyPI's trusted publisher feature - no API tokens needed!
-        # Just configure it once in PyPI settings
+        skip-existing: true
 
   github-release:
     needs: [test, release]


### PR DESCRIPTION
## Summary
- ensure release workflow explicitly sets skip-existing for PyPI publishes

## Testing
- `python -m pytest tests/ -v` (fails: ModuleNotFoundError: No module named 'numpy')
- `python check_static.py` (fails: can't open file)

------
https://chatgpt.com/codex/tasks/task_e_68a237e73e50832fab137fcc597e75bc