### PR TITLE
Cite the version this package actually is

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -7,8 +7,8 @@ authors:
   - family-names: "Sood"
     given-names: "Gaurav"
     email: "contact@gsood.com"
-version: "0.6.0"
-date-released: "2025-05-01"
+version: "0.9.0"
+date-released: "2026-07-31"
 license: MIT
 repository-code: "https://github.com/finite-sample/rank-preserving-calibration"
 url: "https://finite-sample.github.io/rank-preserving-calibration/"


### PR DESCRIPTION
`CITATION.cff` recorded version `0.6.0`; `project.version` is `0.9.0`. Whoever cites this package copies that number, so a stale one outlives the release in someone else's bibliography.


Found by `preen check` sweeping the fleet — this repo was one of eight — and applied with `preen fix citation`, which also moves `date-released` to the date of the tag naming the release rather than leaving a right version beside a wrong date.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011SkMDqnEFUgr7Mbc1HwMqX